### PR TITLE
resolve bug: fail on errors or failures

### DIFF
--- a/junit-to-json/package-lock.json
+++ b/junit-to-json/package-lock.json
@@ -20,7 +20,7 @@
         "babel-jest": "^26.6.3",
         "eslint": "^7.20.0",
         "jest": "^26.6.3",
-        "typescript": "^4.1.3"
+        "typescript": "^4.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7650,9 +7650,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14168,9 +14168,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/junit-to-json/package.json
+++ b/junit-to-json/package.json
@@ -23,6 +23,6 @@
     "babel-jest": "^26.6.3",
     "eslint": "^7.20.0",
     "jest": "^26.6.3",
-    "typescript": "^4.1.3"
+    "typescript": "^4.2.4"
   }
 }

--- a/junit-to-json/src/lib/index.test.ts
+++ b/junit-to-json/src/lib/index.test.ts
@@ -265,3 +265,46 @@ function fullXmlExample() {
     </testsuites>
   `
 }
+
+describe('secondXmlExample', () => {
+  test('correct format returned for failing', () => {
+    const xml = secondXmlExample()
+    const xmlBuffer = Buffer.from(xml)
+    const result = processXmlResult(xmlBuffer)
+    expect(result).not.toBeNull()
+    expect(result.version).toEqual(2)
+    expect(result.status).toEqual('fail')
+    expect(result.tests).toHaveLength(1)
+  })
+})
+
+function secondXmlExample() {
+  return `
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="HammingTest" file="/solution/HammingTest.php" tests="8" assertions="8" errors="0" warnings="0" failures="3" skipped="0" time="0.000761">
+    <testcase name="testNoDifferenceBetweenIdenticalStrands" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="35" assertions="1" time="0.000224"/>
+    <testcase name="testCompleteHammingDistanceOfForSingleNucleotideStrand" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="40" assertions="1" time="0.000051"/>
+    <testcase name="testCompleteHammingDistanceForSmallStrand" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="45" assertions="1" time="0.000049"/>
+    <testcase name="testSmallHammingDistance" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="50" assertions="1" time="0.000044"/>
+    <testcase name="testSmallHammingDistanceInLongerStrand" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="55" assertions="1" time="0.000048"/>
+    <testcase name="testLargeHammingDistance" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="60" assertions="1" time="0.000124">
+      <failure type="PHPUnit\Framework\ExpectationFailedException">HammingTest::testLargeHammingDistance
+Failed asserting that 0 matches expected 4.
+
+/solution/HammingTest.php:62</failure>
+    </testcase>
+    <testcase name="testHammingDistanceInVeryLongStrand" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="65" assertions="1" time="0.000127">
+      <failure type="PHPUnit\Framework\ExpectationFailedException">HammingTest::testHammingDistanceInVeryLongStrand
+Failed asserting that 0 matches expected 9.
+
+/solution/HammingTest.php:67</failure>
+    </testcase>
+    <testcase name="testExceptionThrownWhenStrandsAreDifferentLength" class="HammingTest" classname="HammingTest" file="/solution/HammingTest.php" line="70" assertions="1" time="0.000095">
+      <failure type="PHPUnit\Framework\ExpectationFailedException">HammingTest::testExceptionThrownWhenStrandsAreDifferentLength
+Failed asserting that exception of type "InvalidArgumentException" is thrown.</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+  `
+}

--- a/junit-to-json/src/lib/index.ts
+++ b/junit-to-json/src/lib/index.ts
@@ -19,8 +19,10 @@ export function processXmlResult(xmlContent: Buffer): ExercismTestRunnerResult {
       .map((suite) => suite.testCases)
       .filter(isTestCases)
       .flat(),
-    status: parsed.reduce((s: 'pass' | 'fail', testSuite: TestSuite) => {
-      return testSuite.errors !== 0 ? 'fail' : s
+    status: parsed.reduce<'pass' | 'fail'>((status, testSuite) => {
+      return testSuite.errors !== 0 || testSuite.failures !== 0
+        ? 'fail'
+        : status
     }, 'pass'),
   }
 }

--- a/test/hamming/Hamming.php
+++ b/test/hamming/Hamming.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare (strict_types = 1);
+
+function distance(string $strandA, string $strandB): int
+{
+    return count(array_diff(str_split($strandA), str_split($strandB)));
+}

--- a/test/hamming/HammingTest.php
+++ b/test/hamming/HammingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare (strict_types = 1);
+
+class HammingTest extends PHPUnit\Framework\TestCase
+
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once 'Hamming.php';
+    }
+
+    public function testNoDifferenceBetweenIdenticalStrands(): void
+    {
+        $this->assertEquals(0, distance('A', 'A'));
+    }
+
+    public function testCompleteHammingDistanceOfForSingleNucleotideStrand(): void
+    {
+        $this->assertEquals(1, distance('A', 'G'));
+    }
+
+    public function testCompleteHammingDistanceForSmallStrand(): void
+    {
+        $this->assertEquals(2, distance('AG', 'CT'));
+    }
+
+    public function testSmallHammingDistance(): void
+    {
+        $this->assertEquals(1, distance('AT', 'CT'));
+    }
+
+    public function testSmallHammingDistanceInLongerStrand(): void
+    {
+        $this->assertEquals(1, distance('GGACG', 'GGTCG'));
+    }
+
+    public function testLargeHammingDistance(): void
+    {
+        $this->assertEquals(4, distance('GATACA', 'GCATAA'));
+    }
+
+    public function testHammingDistanceInVeryLongStrand(): void
+    {
+        $this->assertEquals(9, distance('GGACGGATTCTG', 'AGGACGGATTCT'));
+    }
+
+    public function testExceptionThrownWhenStrandsAreDifferentLength(): void
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('DNA strands must be of equal length.');
+        distance('GGACG', 'AGGACGTGG');
+    }
+}


### PR DESCRIPTION
When parsing the phpunit xml output, previously was only counting errors towards test run failure. Now counts errors and assertion failures towards test run failure.