### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ test/
 
 junit-to-json/node_modules/
 junit-to-json/**/*.js
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ junit-to-json/node_modules/
 junit-to-json/**/*.js
 .appends
 .gitattributes
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@ junit-to-json/**/*.js
 .appends
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ test/
 junit-to-json/node_modules/
 junit-to-json/**/*.js
 .appends
+.gitattributes


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
