### PR TITLE
handle php fatal error

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -35,6 +35,11 @@ jobs:
           cd junit-to-json
           npm install
 
+      - name: Install Other Deps
+        shell: bash
+        run: |
+          apt-get install -y jo
+
       - name: Smoke Test
         run: |
           ./bin/run.sh hello-world ./test/hello-world ./test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0.12-cli-bullseye
 
 # Install SSL ca certificates
 RUN apt-get update && \
-  apt-get install curl bash -y
+  apt-get install curl bash jo -y
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
Pointed out in slack that when PHP encounters fatal error before phpunit able to return, the test runner is mistakenly passing the solution.

This is because the junit parser `junit-to-json` is receiving an empty file without failing tests.

`run.sh` now catches php fatal error code 255, and returns proper test runner output with error message to test organizer.