### PR TITLE
Revert "Revert "Bump docker/build-push-action from 2.7.0 to 2.9.0""

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # 2.2.2
+        uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b # 2.2.2
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Reverted this initially to test if this bump was the cause of this failure as nothing has changed recently in this repo.  Guessing some other issue is occuring here in the docker image build process.

Reverts exercism/php-test-runner#33