### PR TITLE
Update Dockerfile PHP image to 8.1.3, bump ds to 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0-cli-bullseye
+FROM php:8.1.3-cli-bullseye
 
 # Install SSL ca certificates
 RUN apt-get update && \
@@ -10,7 +10,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/install-php-extensions && \
-  install-php-extensions ds-1.3.0 intl
+  install-php-extensions ds-1.4.0 intl
 
 # Install Node
 RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \


### PR DESCRIPTION
Merging an unrelated PR for a github action triggered a now failing build process.  Removing ds 1.3.0 from the build script resolved this issue, so bumped both the image from 8.1 to 8.1.3 and ds from 1.3.0 to 1.4.0

My best guess is that ds retagged a new release as 1.3.0 which then broke. 🤷🏻  