### PR TITLE
Update php test runner to handle empty output.xml

### DIFF
--- a/junit-to-json/package-lock.json
+++ b/junit-to-json/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "junit-to-json",
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/junit-to-json/src/lib/index.test.ts
+++ b/junit-to-json/src/lib/index.test.ts
@@ -255,8 +255,9 @@ describe('processXmlResult', () => {
     expect(result.version).toBe(2)
     expect(result.status).toEqual('error')
     expect(result.tests).toHaveLength(0)
-    expect(result.message).toBe("Unit test run did not produce any results. Did the tests finish " +
-      "completely?\n\nUsing the `die` function in your code will cause the test run to not produce any output.")
+    expect(result.message).toBe("Test run did not produce any output. Check your code to see if the code " +
+      "exits unexpectedly before the report is generated.\n\nE.g. Using the `die` function will cause the test " +
+      "runner to exit unexpectedly.")
   })
 })
 

--- a/junit-to-json/src/lib/index.test.ts
+++ b/junit-to-json/src/lib/index.test.ts
@@ -247,6 +247,21 @@ describe('processXmlResult', () => {
     expect(result.status).toEqual('fail')
     expect(result.tests).toHaveLength(2)
   })
+
+  test('parses empty output as an error', () => {
+    // If the student puts exit or die calls in their code, then PHPUnit will
+    // exit without producing any output in the output.xml file.
+    const xml = ``
+
+    const xmlBuffer = Buffer.from(xml)
+    const result = processXmlResult(xmlBuffer)
+
+    expect(result).not.toBeNull()
+    expect(result.version).toBe(2)
+    expect(result.status).toEqual('error')
+    expect(result.tests).toHaveLength(0)
+    expect(result.message).toBe('Unit test run did not produce any results. Did the tests die?')
+  })
 })
 
 function fullXmlExample() {

--- a/junit-to-json/src/lib/index.test.ts
+++ b/junit-to-json/src/lib/index.test.ts
@@ -1,11 +1,6 @@
 export {}
-import { load } from 'cheerio'
-import {
-  parseTestCase,
-  parseTestSuite,
-  parseTestSuites,
-  processXmlResult,
-} from './index'
+import {load} from 'cheerio'
+import {parseTestCase, parseTestSuite, parseTestSuites, processXmlResult,} from './index'
 
 describe('parseTestCase', () => {
   test('parses passing test', () => {
@@ -15,7 +10,7 @@ describe('parseTestCase', () => {
     const testCaseEl = load(xml)('testcase')
     const result = parseTestCase(testCaseEl)
 
-    expect(result).toEqual({ name: 'test1', status: 'pass', output: '' })
+    expect(result).toEqual({name: 'test1', status: 'pass', output: ''})
   })
 
   test('parses passing test with system output', () => {
@@ -260,7 +255,8 @@ describe('processXmlResult', () => {
     expect(result.version).toBe(2)
     expect(result.status).toEqual('error')
     expect(result.tests).toHaveLength(0)
-    expect(result.message).toBe('Unit test run did not produce any results. Did the tests die?')
+    expect(result.message).toBe("Unit test run did not produce any results. Did the tests finish " +
+      "completely?\n\nUsing the `die` function in your code will cause the test run to not produce any output.")
   })
 })
 

--- a/junit-to-json/src/lib/index.ts
+++ b/junit-to-json/src/lib/index.ts
@@ -18,8 +18,8 @@ export function processXmlResult(xmlContent: Buffer): ExercismTestRunnerResult {
       version: 2,
       tests: [],
       status: "error",
-      message: "Unit test run did not produce any results. Did the tests finish completely?\n\nUsing the `die` " +
-        "function in your code will cause the test run to not produce any output."
+      message: "Test run did not produce any output. Check your code to see if the code exits unexpectedly before " +
+        "the report is generated.\n\nE.g. Using the `die` function will cause the test runner to exit unexpectedly."
     } as ExercismTestRunnerError
   }
 

--- a/junit-to-json/src/lib/index.ts
+++ b/junit-to-json/src/lib/index.ts
@@ -18,7 +18,8 @@ export function processXmlResult(xmlContent: Buffer): ExercismTestRunnerResult {
       version: 2,
       tests: [],
       status: "error",
-      message: "Unit test run did not produce any results. Did the tests die?"
+      message: "Unit test run did not produce any results. Did the tests finish completely?\n\nUsing the `die` " +
+        "function in your code will cause the test run to not produce any output."
     } as ExercismTestRunnerError
   }
 

--- a/junit-to-json/src/lib/index.ts
+++ b/junit-to-json/src/lib/index.ts
@@ -1,4 +1,4 @@
-import { load } from 'cheerio'
+import {load} from 'cheerio'
 
 type CheerioRoot = ReturnType<typeof load>
 type CheerioSelection = ReturnType<CheerioRoot>
@@ -10,8 +10,17 @@ function isTestCases(
 }
 
 export function processXmlResult(xmlContent: Buffer): ExercismTestRunnerResult {
-  const $ = load(xmlContent, { xmlMode: true })
+  const $ = load(xmlContent, {xmlMode: true})
   const parsed = parseTestSuites($)
+
+  if (parsed.length === 0) {
+    return {
+      version: 2,
+      tests: [],
+      status: "error",
+      message: "Unit test run did not produce any results. Did the tests die?"
+    } as ExercismTestRunnerError
+  }
 
   return {
     version: 2,
@@ -24,7 +33,7 @@ export function processXmlResult(xmlContent: Buffer): ExercismTestRunnerResult {
         ? 'fail'
         : status
     }, 'pass'),
-  }
+  };
 }
 
 export function parseTestSuites($: CheerioRoot): TestSuite[] {


### PR DESCRIPTION
If a student uses die or exit in their code, PHPUnit
will exit before it produces any output. This change will
treat an empty output.xml as an error so the tests will
not be interpreted as running successfully.