### PR TITLE
Increase memory limit for running PHP tests to 300MB

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -14,6 +14,7 @@ function main {
 
   set +e
   phpunit_output=$(eval "${PHPUNIT_BIN}" \
+    -d memory_limit=300M \
     --log-junit "${output_dir%/}/${XML_RESULTS}" \
     --verbose \
     --no-configuration \


### PR DESCRIPTION
This allows the robot names exercise to run where all names are generated first and then removed as they are used. That solution takes ~260-270MB to execute within PHPUnit. It can also allow for O(1) new name assignments. The solution that tracks used names will get exponentially slower as collisions become more and more likely. The tests for PHP only currently try 10k names. Other languages have tests that exercise the entire possible robot namespace. 