### PR TITLE
Handle runtime errors in students global code

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -49,6 +49,15 @@ function main {
     return 0;
   fi
 
+  # This catches runtime errors in "global student code" (during `require_once`)
+  if [[ "${phpunit_exit_code}" -eq 2 ]]; then
+    if ! grep -q '<testcase' "${output_dir%/}/${JUNIT_RESULTS}"; then
+        output="${output#*" MB"}"
+        jo version=3 status=error message="${output//"$solution_dir/"/""}" tests="[]" > "${output_dir%/}/${EXERCISM_RESULTS}"
+        return 0;
+    fi
+  fi
+
   php junit-handler/run.php \
     "${output_dir%/}/${EXERCISM_RESULTS}" \
     "${output_dir%/}/${JUNIT_RESULTS}" \

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -21,7 +21,7 @@ function main {
 
   set +e
   if ! output=$(php -l "${solution_dir}"/*.php 2>&1 1>/dev/null); then
-    jo version=3 status=error message="${output/"$solution_dir/"/""}" tests="[]" > "${output_dir%/}/${EXERCISM_RESULTS}"
+    jo version=3 status=error message="${output//"$solution_dir/"/""}" tests="[]" > "${output_dir%/}/${EXERCISM_RESULTS}"
     return 0;
   fi
 
@@ -45,7 +45,7 @@ function main {
   # PHPUnit fails to catch some issue in its internals. It cannot be provoked
   # by us for testing our code
   if [[ "${phpunit_exit_code}" -eq 255 ]]; then
-    jo version=3 status=error message="${output/"$solution_dir/"/""}" tests="[]" > "${output_dir%/}/${EXERCISM_RESULTS}"
+    jo version=3 status=error message="${output//"$solution_dir/"/""}" tests="[]" > "${output_dir%/}/${EXERCISM_RESULTS}"
     return 0;
   fi
 

--- a/tests/runtime-error-in-global-code/HelloWorld.php
+++ b/tests/runtime-error-in-global-code/HelloWorld.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function helloWorld(int $value)
+{
+    throw new \BadFunctionCallException("Implement the helloWorld() function");
+}
+
+// Causes a type error at runtime only, outside of a test function
+helloWorld('string');

--- a/tests/runtime-error-in-global-code/HelloWorldTest.php
+++ b/tests/runtime-error-in-global-code/HelloWorldTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+class HelloWorldTest extends PHPUnit\Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once 'HelloWorld.php';
+    }
+
+    public function testHelloWorld(): void
+    {
+        $this->assertEquals('Hello, World!', helloWorld());
+    }
+}

--- a/tests/runtime-error-in-global-code/expected_results.json
+++ b/tests/runtime-error-in-global-code/expected_results.json
@@ -1,0 +1,1 @@
+{"version":3,"status":"error","message":"\n\nThere was 1 error:\n\n1) HelloWorldTest\nTypeError: helloWorld(): Argument #1 ($value) must be of type int, string given, called in HelloWorld.php on line 11\n\nHelloWorld.php:5\nHelloWorld.php:11\nHelloWorldTest.php:9\n\nERRORS!\nTests: 1, Assertions: 0, Errors: 1.","tests":[]}


### PR DESCRIPTION
Reported in [this forum post](https://forum.exercism.org/t/bug-at-php-windowing-system/11232):

A runtime error in code, that is seen as global code by the students, resulted in reporting a success with no results.

- Added a regression test to simulate that
- Catch the case and report the error

PHPUnit again does not report these errors in the logs, so I had to filter that out in shell code before the logs are processed. Another reason to write an event based processor suggested in #110.