### PR TITLE
Fix flakiness of user output testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![JUnit to JSON Tests](https://github.com/exercism/php-test-runner/workflows/Test%20JUnit-to-JSON/badge.svg) ![Smoke Test](https://github.com/exercism/php-test-runner/workflows/Smoke%20Test/badge.svg) ![Tooling image pushed](https://github.com/exercism/php-test-runner/workflows/Deploy/badge.svg)
+![Smoke Test](https://github.com/exercism/php-test-runner/workflows/Smoke%20Test/badge.svg) ![Tooling image pushed](https://github.com/exercism/php-test-runner/workflows/Deploy/badge.svg)
 
 # PHP Test Runner
 

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -40,11 +40,7 @@ for test_dir in tests/*; do
         "${results_file_path}"
 
     echo "${test_dir_name}: comparing results.json to expected_results.json"
-    diff "${results_file_path}" "${expected_results_file_path}"
-
-    if [ $? -ne 0 ]; then
-        exit_code=1
-    fi
+    diff "${results_file_path}" "${expected_results_file_path}" || exit_code=1
 done
 
 exit ${exit_code}

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Synopsis:
-# Test the test runner by running it against a predefined set of solutions 
+# Test the test runner by running it against a predefined set of solutions
 # with an expected output.
 
 # Output:
@@ -26,7 +26,7 @@ for test_dir in tests/*; do
     bin/run.sh "${test_dir_name}" "${test_dir_path}" "${output_dir_path}"
 
     # OPTIONAL: Normalize the results file
-    # If the results.json file contains information that changes between 
+    # If the results.json file contains information that changes between
     # different test runs (e.g. timing information or paths), you should normalize
     # the results file to allow the diff comparison below to work as expected
     # sed -i -E \

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -34,6 +34,11 @@ for test_dir in tests/*; do
     #   -e "s~${test_dir_path}~/solution~g" \
     #   "${results_file_path}"
 
+    # Normalize the object ID of `var_dump(new stdClass())`
+    sed -i -E \
+        -e 's/(object\(stdClass\))(#[[:digit:]]+)/\1#79/g' \
+        "${results_file_path}"
+
     echo "${test_dir_name}: comparing results.json to expected_results.json"
     diff "${results_file_path}" "${expected_results_file_path}"
 


### PR DESCRIPTION
Since a few weeks the CI fails for no-change re-builds caused by #128. This replaces the varying bit of generated output with a constant value.